### PR TITLE
Fixed links in plugins.sbt to use https

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,7 @@
 //logLevel := Level.Warn
 
 
-resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
+resolvers += "Typesafe repository" at "https://repo.typesafe.com/typesafe/releases/"
 
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.0")
 


### PR DESCRIPTION
Fixed links in plugins.sbt to use https:
Otherwise fresh build fails.